### PR TITLE
chore(auth): sert l'auth sous yc.youlz.fr et y déplace le cookie JWT

### DIFF
--- a/.env
+++ b/.env
@@ -50,5 +50,8 @@ SEASON_ADMIN_URL='https://yc-season.barlito.fr/admin'
 ###< Projects admin URLs ###
 
 ###> lexik/jwt-authentication-bundle ###
-JWT_COOKIE_DOMAIN=.barlito.fr
+# Domaine des applications consommatrices (youl-tcg). Le JWT n'est posé que si
+# l'utilisateur passe par yc.youlz.fr : depuis yc.barlito.fr le navigateur
+# rejette le Set-Cookie, le domaine ne correspondant pas à l'hôte qui répond.
+JWT_COOKIE_DOMAIN=.youlz.fr
 ###< lexik/jwt-authentication-bundle ###

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -27,10 +27,13 @@ services:
 
                 - traefik.http.services.youlcoin.loadbalancer.server.port=80
 
-                - traefik.http.routers.youlcoin.rule=Host(`yc.barlito.fr`)
+                # Les deux domaines sont servis : un cookie ne peut être posé
+                # que par le domaine qui répond, donc l'auth doit répondre sous
+                # youlz.fr pour que ytcg.youlz.fr reçoive le JWT.
+                - traefik.http.routers.youlcoin.rule=Host(`yc.youlz.fr`) || Host(`yc.barlito.fr`)
                 - traefik.http.routers.youlcoin.entrypoints=http
 
-                - traefik.http.routers.youlcoin-secure.rule=Host(`yc.barlito.fr`)
+                - traefik.http.routers.youlcoin-secure.rule=Host(`yc.youlz.fr`) || Host(`yc.barlito.fr`)
                 - traefik.http.routers.youlcoin-secure.entrypoints=https
                 - traefik.http.routers.youlcoin-secure.tls=true
                 - traefik.http.routers.youlcoin-secure.tls.certresolver=letsencrypt

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -27,9 +27,6 @@ services:
 
                 - traefik.http.services.youlcoin.loadbalancer.server.port=80
 
-                # Les deux domaines sont servis : un cookie ne peut être posé
-                # que par le domaine qui répond, donc l'auth doit répondre sous
-                # youlz.fr pour que ytcg.youlz.fr reçoive le JWT.
                 - traefik.http.routers.youlcoin.rule=Host(`yc.youlz.fr`) || Host(`yc.barlito.fr`)
                 - traefik.http.routers.youlcoin.entrypoints=http
 


### PR DESCRIPTION
Pendant de [youl-tcg#132](https://github.com/barlito/youl-tcg/pull/132), qui bascule l'app sur `ytcg.youlz.fr`.

## Pourquoi

Un navigateur n'accepte un `Set-Cookie` que si le domaine du cookie correspond à l'hôte qui répond. Le JWT est émis ici, sur `yc.barlito.fr` : il est donc **impossible** de poser un cookie valable pour `youlz.fr` depuis cet hôte. Sans ce PR, un visiteur de `ytcg.youlz.fr` serait redirigé vers l'auth, repartirait avec un cookie sur `.barlito.fr`, reviendrait toujours non authentifié — boucle infinie.

## Ce que ça change

- **Traefik** : les deux routeurs servent désormais `Host(\`yc.youlz.fr\`) || Host(\`yc.barlito.fr\`)`. L'ancien hôte reste servi pour ne pas casser l'admin existante.
- **`.env`** : `JWT_COOKIE_DOMAIN` passe de `.barlito.fr` à `.youlz.fr`.

Le DNS est prêt : `*.youlz.fr` est un wildcard vers 51.68.154.52.

## Impact vérifié

- **L'admin de ce projet n'est pas impactée** : le firewall `main` s'authentifie en session + `remember_me`, pas avec ce cookie JWT. Le cookie de session n'a pas de `cookie_domain` configuré, il reste donc lié à l'hôte.
- **Seul consommateur du cookie : youl-tcg.** Vérifié sur l'ensemble des repos locaux.
- `yc-season.barlito.fr` (lien `SEASON_ADMIN_URL` du menu admin) ne répond pas et n'a pas de certificat valide : lien mort, aucun impact.
- Une reconnexion Discord sera nécessaire la première fois qu'on passe par `yc.youlz.fr`, la session n'étant pas partagée entre les deux hôtes.

## ⚠️ Prérequis avant déploiement

Ajouter `https://yc.youlz.fr/connect/discord/check` aux **redirect URIs** de l'application Discord, sinon le retour d'OAuth échouera sur le nouvel hôte.

## À faire ensuite (hors scope)

`/refresh_token` accepte n'importe quel `_target_path` commençant par `http` sans liste blanche (`DiscordController::refreshToken`). C'est une redirection ouverte, qui mériterait un filtre sur les domaines maintenant qu'il y en a deux.